### PR TITLE
Fix capitalization of container tag

### DIFF
--- a/core/cfn/ci_container_poky.yml
+++ b/core/cfn/ci_container_poky.yml
@@ -69,7 +69,7 @@ Resources:
             Value: !Ref 'AWS::AccountId'
             Type: PLAINTEXT
           - Name: IMAGE_TAG
-            Value: Latest
+            Value: latest
             Type: PLAINTEXT
           - Name: dockerhub_username
             Value: !Sub "dockerhub_${Prefix}:username"


### PR DESCRIPTION
The container was tagged 'Latest' but convention (and other templates)
use 'latest.'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
