### PR TITLE
ci: convert checklayer cfn template to run on PRs

### DIFF
--- a/core/cfn/ci_checklayer.yml
+++ b/core/cfn/ci_checklayer.yml
@@ -15,8 +15,13 @@ Parameters:
     Description: >-
         The Yocto release, i.e. zeus, dunfell, etc.
     Type: String
+  GitHubOrg:
+    Description: >-
+       The GitHub organization or user to set the codebuild project for.
+    Type: String
+    Default: "aws"
 
-Resources:    
+Resources:
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -26,7 +31,7 @@ Resources:
       Description: Layercheck- check layer validity
       Environment:
         Type: LINUX_CONTAINER
-        ComputeType: BUILD_GENERAL1_2XLARGE
+        ComputeType: BUILD_GENERAL1_LARGE
         Image: !Ref ContainerRegistryUri
         PrivilegedMode: true
         ImagePullCredentialsType: CODEBUILD
@@ -36,9 +41,24 @@ Resources:
             Value: !Ref YoctoProjectRelease
       Name: !Ref AWS::StackName
       ServiceRole: !Ref CodeBuildRole
+      Triggers:
+        Webhook: true
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PULL_REQUEST_UPDATED,  PULL_REQUEST_CREATED, PULL_REQUEST_REOPENED
+            - Type: BASE_REF
+              Pattern: !Join
+                - ''
+                - - '^refs/heads/'
+                  - !Ref YoctoProjectRelease
+              ExcludeMatchedPattern: false
       Source:
         BuildSpec: qa/buildspec.checklayer.yml
-        Location: https://github.com/aws/meta-aws
+        Location: !Join
+          - ''
+          - - 'https://github.com/'
+            - !Ref GitHubOrg
+            - '/meta-aws'
         Type: GITHUB
         SourceIdentifier: meta_aws_layercheck
       SourceVersion: !Join


### PR DESCRIPTION
The existing checklayer cfn template runs only via a direct invocation.
This change adds the webhook trigger feature of CodeBuild Projects to
run on any branch ('^ref/head/BRANCHNAME') that starts with the yocto
release name. e.g. This should cover merging into both 'hardknott' and
'hardknott-next'.

There are a few additional changes:
* The GitHub 'organization' parameterized to make it easier to deploy
on forks.
* Minor formatting changes.
* Build Environment compute type is downgraded to avoid throttling.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
